### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.vdr.vnsi/addon.xml
+++ b/pvr.vdr.vnsi/addon.xml
@@ -6,7 +6,7 @@
   provider-name="FernetMenta, Team XBMC">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
     <import addon="xbmc.codec" version="1.0.1"/>
     <import addon="kodi.guilib" version="5.8.0"/>
   </requires>

--- a/pvr.vdr.vnsi/addon.xml
+++ b/pvr.vdr.vnsi/addon.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="1.10.8"
+  version="1.11.0"
   name="VDR VNSI Client"
-  provider-name="FernetMenta, Team XBMC">
+  provider-name="FernetMenta, Team Kodi">
   <requires>
     <c-pluff version="0.1"/>
     <import addon="xbmc.pvr" version="1.9.7"/>

--- a/src/VNSIData.cpp
+++ b/src/VNSIData.cpp
@@ -409,6 +409,9 @@ PVR_ERROR cVNSIData::GetTimerInfo(unsigned int timernumber, PVR_TIMER &tag)
       return PVR_ERROR_SERVER_ERROR;
   }
 
+  /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+  tag.iTimerType = PVR_TIMER_TYPE_NONE;
+
   tag.iClientIndex      = vresp->extract_U32();
   int iActive           = vresp->extract_U32();
   int iRecording        = vresp->extract_U32();
@@ -427,7 +430,6 @@ PVR_ERROR cVNSIData::GetTimerInfo(unsigned int timernumber, PVR_TIMER &tag)
   tag.endTime           = vresp->extract_U32();
   tag.firstDay          = vresp->extract_U32();
   tag.iWeekdays         = vresp->extract_U32();
-  tag.bIsRepeating      = tag.iWeekdays == 0 ? false : true;
   char *strTitle = vresp->extract_String();
   strncpy(tag.strTitle, strTitle, sizeof(tag.strTitle) - 1);
   delete[] strTitle;
@@ -460,6 +462,10 @@ bool cVNSIData::GetTimersList(ADDON_HANDLE handle)
     {
       PVR_TIMER tag;
       memset(&tag, 0, sizeof(tag));
+
+      /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+      tag.iTimerType = PVR_TIMER_TYPE_NONE;
+
       tag.iClientIndex      = vresp->extract_U32();
       int iActive           = vresp->extract_U32();
       int iRecording        = vresp->extract_U32();
@@ -478,7 +484,6 @@ bool cVNSIData::GetTimersList(ADDON_HANDLE handle)
       tag.endTime           = vresp->extract_U32();
       tag.firstDay          = vresp->extract_U32();
       tag.iWeekdays         = vresp->extract_U32();
-      tag.bIsRepeating      = tag.iWeekdays == 0 ? false : true;
       char *strTitle = vresp->extract_String();
       strncpy(tag.strTitle, strTitle, sizeof(tag.strTitle) - 1);
       tag.iMarginStart      = 0;
@@ -546,7 +551,7 @@ PVR_ERROR cVNSIData::AddTimer(const PVR_TIMER &timerinfo)
   if (!vrp.add_U32(timerinfo.iClientChannelUid)) return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(starttime))  return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(endtime))    return PVR_ERROR_UNKNOWN;
-  if (!vrp.add_U32(timerinfo.bIsRepeating ? timerinfo.firstDay : 0))   return PVR_ERROR_UNKNOWN;
+  if (!vrp.add_U32(timerinfo.iWeekdays != PVR_WEEKDAY_NONE ? timerinfo.firstDay : 0))   return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(timerinfo.iWeekdays))return PVR_ERROR_UNKNOWN;
   if (!vrp.add_String(path.c_str()))      return PVR_ERROR_UNKNOWN;
   if (!vrp.add_String(""))                return PVR_ERROR_UNKNOWN;
@@ -629,7 +634,7 @@ PVR_ERROR cVNSIData::UpdateTimer(const PVR_TIMER &timerinfo)
   if (!vrp.add_U32(timerinfo.iClientChannelUid)) return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(starttime))  return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(endtime))    return PVR_ERROR_UNKNOWN;
-  if (!vrp.add_U32(timerinfo.bIsRepeating ? timerinfo.firstDay : 0))   return PVR_ERROR_UNKNOWN;
+  if (!vrp.add_U32(timerinfo.iWeekdays != PVR_WEEKDAY_NONE ? timerinfo.firstDay : 0))   return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(timerinfo.iWeekdays))return PVR_ERROR_UNKNOWN;
   if (!vrp.add_String(timerinfo.strTitle))   return PVR_ERROR_UNKNOWN;
   if (!vrp.add_String(""))                return PVR_ERROR_UNKNOWN;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -537,6 +537,12 @@ PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &g
 /*******************************************/
 /** PVR Timer Functions                   **/
 
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+{
+  /* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 int GetTimersAmount(void)
 {
   if (!VNSIData)
@@ -550,6 +556,7 @@ PVR_ERROR GetTimers(ADDON_HANDLE handle)
   if (!VNSIData)
     return PVR_ERROR_SERVER_ERROR;
 
+  /* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
   return (VNSIData->GetTimersList(handle) ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR);
 }
 
@@ -561,11 +568,12 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return VNSIData->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForce)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForce, bool /*bDeleteScheduled*/)
 {
   if (!VNSIData)
     return PVR_ERROR_SERVER_ERROR;
 
+  /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
   return VNSIData->DeleteTimer(timer, bForce);
 }
 


### PR DESCRIPTION
For, J**** PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J**** and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.