### PR TITLE
Bump add-on for PVR API 3.0.0 (Compatibility mode)

### DIFF
--- a/pvr.vdr.vnsi/addon.xml.in
+++ b/pvr.vdr.vnsi/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="1.11.3"
+  version="1.11.4"
   name="VDR VNSI Client"
   provider-name="FernetMenta, Team Kodi">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="2.1.0"/>
+    <import addon="xbmc.pvr" version="3.0.0"/>
     <import addon="xbmc.codec" version="1.0.1"/>
     <import addon="kodi.guilib" version="5.8.0"/>
   </requires>


### PR DESCRIPTION
Addon part of https://github.com/xbmc/xbmc/pull/7626
Add on currently using 1.9.7 API compatibility code
No further add-on changes required for minimal support