### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.vdr.vnsi/addon.xml.in
+++ b/pvr.vdr.vnsi/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="1.11.6"
+  version="1.11.7"
   name="VDR VNSI Client"
   provider-name="FernetMenta, Team Kodi">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
     <import addon="xbmc.codec" version="1.0.1"/>
     <import addon="kodi.guilib" version="5.8.0"/>
   </requires>

--- a/src/VNSIData.cpp
+++ b/src/VNSIData.cpp
@@ -344,6 +344,7 @@ bool cVNSIData::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel
     tag.strIMDBNumber       = "";
     if (tag.strPlotOutline)
       tag.strEpisodeName    = strdup(tag.strPlotOutline);
+    tag.iFlags              = EPG_TAG_FLAG_UNDEFINED;
 
     PVR->TransferEpgEntry(handle, &tag);
     delete[] tag.strTitle;


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075