### PR TITLE
Revert "requestpacket: use "constexpr" instead of "const" for constants"

### DIFF
--- a/src/requestpacket.h
+++ b/src/requestpacket.h
@@ -59,6 +59,6 @@ class cRequestPacket
 
     void checkExtend(size_t by);
 
-    constexpr static size_t headerLength = 16;
-    constexpr static size_t userDataLenPos = 12;
+    const static size_t headerLength = 16;
+    const static size_t userDataLenPos = 12;
 };


### PR DESCRIPTION
Not supported by VS 2013