### PR TITLE
VNSIData: re-add the TransferRecordingEntry() call

### DIFF
--- a/src/VNSIData.cpp
+++ b/src/VNSIData.cpp
@@ -777,6 +777,8 @@ PVR_ERROR cVNSIData::GetRecordingsList(ADDON_HANDLE handle)
 
     strRecordingId.Format("%i", vresp->extract_U32());
     strncpy(tag.strRecordingId, strRecordingId.c_str(), sizeof(tag.strRecordingId) - 1);
+
+    PVR->TransferRecordingEntry(handle, &tag);
   }
 
   return PVR_ERROR_NO_ERROR;


### PR DESCRIPTION
This call got lost in commit de2507bd0b