### PR TITLE
Fix timer type definition for EPG search timer.

### DIFF
--- a/pvr.vdr.vnsi/addon.xml.in
+++ b/pvr.vdr.vnsi/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="2.6.4"
+  version="2.6.5"
   name="VDR VNSI Client"
   provider-name="FernetMenta, Team Kodi">
   <requires>

--- a/src/VNSIData.cpp
+++ b/src/VNSIData.cpp
@@ -716,8 +716,7 @@ PVR_ERROR cVNSIData::GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
       memset(&types[*size], 0, sizeof(types[*size]));
       types[*size].iId = VNSI_TIMER_TYPE_EPG_SEARCH;
       strncpy(types[*size].strDescription, XBMC->GetLocalizedString(30204), 64);
-      types[*size].iAttributes = PVR_TIMER_TYPE_IS_MANUAL |
-                                 PVR_TIMER_TYPE_IS_REPEATING |
+      types[*size].iAttributes = PVR_TIMER_TYPE_IS_REPEATING |
                                  PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
                                  PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
                                  PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH |


### PR DESCRIPTION
epg-based timer types must not set PVR_TIMER_TYPE_IS_MANUAL as this defines a non-epg-based timer type. 

problem reported here: http://forum.kodi.tv/showthread.php?tid=261847&pid=2407997#pid2407997 => "If I open "timers" from home screen and then again "add timer" i a get settings dialog which offers timer type "single" and "recurring" but nothing epg based."

@FernetMenta ping