### PR TITLE
change libXBMC_codec to libXBMC_pvr

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -56,7 +56,6 @@ std::string   g_szIconPath              = "";
 int prioVals[] = {0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,85,90,95,99,100};
 
 CHelper_libXBMC_addon *XBMC = nullptr;
-CHelper_libXBMC_codec *CODEC = nullptr;
 CHelper_libKODI_guilib *GUI = nullptr;
 CHelper_libXBMC_pvr *PVR = nullptr;
 
@@ -96,20 +95,10 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
     return ADDON_STATUS_PERMANENT_FAILURE;
   }
 
-  CODEC = new CHelper_libXBMC_codec;
-  if (!CODEC->RegisterMe(hdl))
-  {
-    SAFE_DELETE(CODEC);
-    SAFE_DELETE(GUI);
-    SAFE_DELETE(XBMC);
-    return ADDON_STATUS_PERMANENT_FAILURE;
-  }
-
   PVR = new CHelper_libXBMC_pvr;
   if (!PVR->RegisterMe(hdl))
   {
     SAFE_DELETE(PVR);
-    SAFE_DELETE(CODEC);
     SAFE_DELETE(GUI);
     SAFE_DELETE(XBMC);
     return ADDON_STATUS_PERMANENT_FAILURE;
@@ -246,8 +235,6 @@ ADDON_STATUS ADDON_GetStatus()
 
 void ADDON_Destroy()
 {
-  SAFE_DELETE(CODEC);
-
   if (VNSIDemuxer)
     SAFE_DELETE(VNSIDemuxer);
 

--- a/src/client.h
+++ b/src/client.h
@@ -21,7 +21,6 @@
  */
 
 #include "libXBMC_addon.h"
-#include "libXBMC_codec.h"
 #include "libXBMC_pvr.h"
 #include "libKODI_guilib.h"
 
@@ -43,6 +42,5 @@ extern int          g_iTimeshift;
 extern std::string  g_szIconPath;         ///< path to channel icons
 
 extern ADDON::CHelper_libXBMC_addon *XBMC;
-extern CHelper_libXBMC_codec *CODEC;
 extern CHelper_libKODI_guilib *GUI;
 extern CHelper_libXBMC_pvr   *PVR;

--- a/src/tools.h
+++ b/src/tools.h
@@ -34,5 +34,4 @@ uint64_t htonll(uint64_t a);
 #endif
 #endif
 
-#include "libXBMC_codec.h"
 #include "xbmc_codec_descriptor.hpp"

--- a/src/xbmc_codec_descriptor.hpp
+++ b/src/xbmc_codec_descriptor.hpp
@@ -20,7 +20,7 @@
 #ifndef XBMC_CODEC_DESCRIPTOR_HPP
 #define	XBMC_CODEC_DESCRIPTOR_HPP
 
-#include "kodi/libXBMC_codec.h"
+#include "kodi/libXBMC_pvr.h"
 
 /**
  * Adapter which converts codec names used by tvheadend and VDR into their 
@@ -48,13 +48,13 @@ public:
     CodecDescriptor retVal;
     // some of Tvheadend's and VDR's codec names don't match ffmpeg's, so translate them to something ffmpeg understands
     if (!strcmp(strCodecName, "MPEG2AUDIO"))
-      retVal = CodecDescriptor(CODEC->GetCodecByName("MP2"), strCodecName);
+      retVal = CodecDescriptor(PVR->GetCodecByName("MP2"), strCodecName);
     else if (!strcmp(strCodecName, "MPEGTS"))
-      retVal = CodecDescriptor(CODEC->GetCodecByName("MPEG2VIDEO"), strCodecName);
+      retVal = CodecDescriptor(PVR->GetCodecByName("MPEG2VIDEO"), strCodecName);
     else if (!strcmp(strCodecName, "TEXTSUB"))
-      retVal = CodecDescriptor(CODEC->GetCodecByName("TEXT"), strCodecName);
+      retVal = CodecDescriptor(PVR->GetCodecByName("TEXT"), strCodecName);
     else
-      retVal = CodecDescriptor(CODEC->GetCodecByName(strCodecName), strCodecName);
+      retVal = CodecDescriptor(PVR->GetCodecByName(strCodecName), strCodecName);
 
     return retVal;
   }


### PR DESCRIPTION
Only to kodi-agile!

This is to remove libXBMC_codec and do the function of them direct on libXBMC_pvr.

Related to: https://github.com/FernetMenta/kodi-agile/pull/49