### PR TITLE
When calling Login() sometimes vresp is set, but invalid.

### DIFF
--- a/src/VNSISession.cpp
+++ b/src/VNSISession.cpp
@@ -137,6 +137,17 @@ bool cVNSISession::Login()
       XBMC->Log(LOG_NOTICE, "Logged in at '%lu+%i' to '%s' Version: '%s' with protocol version '%d'",
         vdrTime, vdrTimeOffset, ServerName, ServerVersion, protocol);
   }
+  catch (const std::out_of_range& e)
+  {
+    XBMC->Log(LOG_ERROR, "%s - %s", __FUNCTION__, e.what());
+    if (m_socket)
+    {
+      m_socket->Close();
+      delete m_socket;
+      m_socket = NULL;
+    }
+    return false;
+  }
   catch (const char * str)
   {
     XBMC->Log(LOG_ERROR, "%s - %s", __FUNCTION__,str);


### PR DESCRIPTION
In those cases vresp->extract_U32() throws an out_of_bound exception which is currently not catched and kills KODI.
Therefore just catch the exception and return false.