### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 
 add_definitions(-DUSE_DEMUX)
@@ -81,7 +80,6 @@ endif()
 message(STATUS "Configured render system: ${APP_RENDER_SYSTEM}")
 
 include_directories(${INCLUDES}
-                    ${kodiplatform_INCLUDE_DIRS}
                     ${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR})
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-vdr-vnsi
 Priority: extra
 Maintainer: fernetmenta <fernetmenta@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, libtinyxml-dev,
-               libkodiplatform-dev (>= 17.1.0), kodi-addon-dev,
+               libp8-platform-dev, kodi-addon-dev,
                libgles2-mesa-dev [arm], libgl1-mesa-dev [i386 amd64], pkg-config
 Standards-Version: 3.9.4
 Section: libs


### PR DESCRIPTION
The pvr.vdr.vnsi binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.