### PR TITLE
Backport d8af242 ("[cmake] remove usage of kodi-platform", 2019-05-02) to Leia

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(pvr.vdr.vnsi)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 
 add_definitions(-DUSE_DEMUX)
@@ -78,7 +77,6 @@ endif()
 message(STATUS "Configured render system: ${APP_RENDER_SYSTEM}")
 
 include_directories(${INCLUDES}
-                    ${kodiplatform_INCLUDE_DIRS}
                     ${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR}/..) # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-vdr-vnsi
 Priority: extra
 Maintainer: fernetmenta <fernetmenta@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, libtinyxml-dev,
-               libkodiplatform-dev (>= 17.1.0), kodi-addon-dev,
+               libp8-platform-dev, kodi-addon-dev,
                libgles2-mesa-dev [arm], libgl1-mesa-dev [i386 amd64], pkg-config
 Standards-Version: 3.9.4
 Section: libs


### PR DESCRIPTION
The pvr.vdr.vnsi binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.
Add dependency to libp8-platform-dev because libkodiplatform-dev
pulled that dependency in as a side effect. Fix that bug too by
adding an explicit dependency.

Signed-off-by: Olaf Hering <olaf@aepfle.de>

---

As the Leia branch is still being updated I suggest adding this one. I've used it successfully on top of release 3.6.3. 
Thanks @olafhering!
