### PR TITLE
add p8-platform to addon itself as depends

### DIFF
--- a/depends/common/p8-platform/p8-platform.txt
+++ b/depends/common/p8-platform/p8-platform.txt
@@ -1,0 +1,1 @@
+p8-platform https://github.com/xbmc/platform.git cee64e9dc0b69e8d286dc170a78effaabfa09c44

--- a/depends/windowsstore/p8-platform/p8-platform.txt
+++ b/depends/windowsstore/p8-platform/p8-platform.txt
@@ -1,0 +1,1 @@
+p8-platform https://github.com/afedchin/platform.git win10

--- a/pvr.vdr.vnsi/changelog.txt
+++ b/pvr.vdr.vnsi/changelog.txt
@@ -1,3 +1,17 @@
+4.2.4
+- Replace AppVeyor with Azure for test build (better performance)
+- Add p8-platform to addon depends instead of from kodi
+- Updated Language files from Transifex
+
+4.2.3
+- Updated Language files from Transifex
+
+4.2.2
+- Updated Language files from Transifex
+
+4.2.1
+- Updated Language files from Transifex
+
 4.2.0
 - Recompile for 6.1.0 PVR Addon API compatibility
 


### PR DESCRIPTION
This is intended to significantly speed up the construction times for those who do not use these dependencies (most addons without this).

This will also happen to all other PVRs that need it and also allows you to add your own versions if necessary.

After converting this will be removed from Kodi.
Only used on the Matrix branches, the others remain with Kodi.