### PR TITLE
8.2.2: Fix: kissnet update fixing Windows socket connection issue

### DIFF
--- a/lib/kissnet/kissnet.hpp
+++ b/lib/kissnet/kissnet.hpp
@@ -735,7 +735,7 @@ namespace kissnet
 				if (error == SOCKET_ERROR)
 				{
 					error = get_error_code();
-					if (error == EAGAIN || error == EINPROGRESS)
+					if (error == EWOULDBLOCK || error == EAGAIN || error == EINPROGRESS)
 					{
 						struct timeval tv;
 						tv.tv_sec = static_cast<long>(timeout / 1000);

--- a/pvr.vdr.vnsi/addon.xml.in
+++ b/pvr.vdr.vnsi/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="8.2.1"
+  version="8.2.2"
   name="VDR VNSI Client"
   provider-name="Team Kodi, FernetMenta">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Fixes a regression that slipped in with latest kissnet update. That regression prevented connecting to tvh backend on Windows. :-/