### PR TITLE
fix read errors during Kodi's start and connection restart 

### DIFF
--- a/pvr.vdr.vnsi/addon.xml.in
+++ b/pvr.vdr.vnsi/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="20.2.1"
+  version="20.2.2"
   name="VDR VNSI Client"
   provider-name="Team Kodi, FernetMenta">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vdr.vnsi/changelog.txt
+++ b/pvr.vdr.vnsi/changelog.txt
@@ -1,3 +1,6 @@
+v20.2.2
+- Fix connection errors on Kodi start and during backend reconnections
+
 v20.2.1
 - Fix crash on some channels
 

--- a/src/ClientInstance.h
+++ b/src/ClientInstance.h
@@ -174,4 +174,5 @@ private:
 
   std::atomic<bool> m_running = {false};
   std::thread m_thread;
+  std::thread m_startInformThread;
 };


### PR DESCRIPTION
Related to issue https://github.com/kodi-pvr/pvr.vdr.vnsi/issues/162

Here how now showed during Kodi's start of if the backend connection was not available on Kodi start and done later.

![Bildschirmfoto vom 2022-01-15 21-56-22](https://user-images.githubusercontent.com/6879739/149637448-2406a76d-2290-4d26-b9f3-fbe2506652f5.png)

The way how fixed not the best, but it works.
With the `kodi::addon::CInstancePVRClient::ConnectionStateChange` call to Kodi, the process was blocked for some seconds and all other tries has created read errors in this time.
By this was then e.g. the timer data wrong or the asked interface version has given 0 (relates to other errors reported by @phunkyfish).
This change makes them now on Kodi's start by "Start" call and on restarts by independent thread.