### PR TITLE
[Matrix] fix read errors during Kodi's start and connection restart

### DIFF
--- a/pvr.vdr.vnsi/addon.xml.in
+++ b/pvr.vdr.vnsi/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="19.0.2"
+  version="19.0.3"
   name="VDR VNSI Client"
   provider-name="Team Kodi, FernetMenta">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vdr.vnsi/changelog.txt
+++ b/pvr.vdr.vnsi/changelog.txt
@@ -1,3 +1,6 @@
+v19.0.3
+- Fix connection errors on Kodi start and during backend reconnections
+
 v19.0.2
 - Fix crash on some channels
 

--- a/src/ClientInstance.cpp
+++ b/src/ClientInstance.cpp
@@ -103,6 +103,8 @@ CVNSIClientInstance::~CVNSIClientInstance()
   m_running = false;
   if (m_thread.joinable())
     m_thread.join();
+  if (m_startInformThread.joinable())
+    m_startInformThread.join();
   Close();
 }
 
@@ -116,13 +118,15 @@ void CVNSIClientInstance::OnReconnect()
 {
   EnableStatusInterface(true, false);
 
-  kodi::addon::CInstancePVRClient::ConnectionStateChange("vnsi connection established",
-                                                         PVR_CONNECTION_STATE_CONNECTED,
-                                                         kodi::GetLocalizedString(30045));
+  m_startInformThread = std::thread([&]() {
+    kodi::addon::CInstancePVRClient::ConnectionStateChange("vnsi connection established",
+                                                          PVR_CONNECTION_STATE_CONNECTED,
+                                                          kodi::GetLocalizedString(30045));
 
-  kodi::addon::CInstancePVRClient::TriggerChannelUpdate();
-  kodi::addon::CInstancePVRClient::TriggerTimerUpdate();
-  kodi::addon::CInstancePVRClient::TriggerRecordingUpdate();
+    kodi::addon::CInstancePVRClient::TriggerChannelUpdate();
+    kodi::addon::CInstancePVRClient::TriggerTimerUpdate();
+    kodi::addon::CInstancePVRClient::TriggerRecordingUpdate();
+  });
 }
 
 bool CVNSIClientInstance::Start(const std::string& hostname,
@@ -1750,7 +1754,9 @@ std::unique_ptr<cResponsePacket> CVNSIClientInstance::ReadResult(cRequestPacket*
 
   std::unique_lock<std::recursive_mutex> lock(m_queue.m_mutex);
   if (cVNSISession::TransmitMessage(vrp) &&
-      message.m_condition.wait_for(lock, std::chrono::milliseconds(CVNSISettings::Get().GetConnectTimeout() * 1000)) == std::cv_status::timeout)
+      message.m_condition.wait_for(
+          lock, std::chrono::seconds(CVNSISettings::Get().GetConnectTimeout())) ==
+          std::cv_status::timeout)
   {
     kodi::Log(ADDON_LOG_ERROR, "%s - request timed out after %d seconds", __func__,
               CVNSISettings::Get().GetConnectTimeout());

--- a/src/ClientInstance.h
+++ b/src/ClientInstance.h
@@ -174,4 +174,5 @@ private:
 
   std::atomic<bool> m_running = {false};
   std::thread m_thread;
+  std::thread m_startInformThread;
 };


### PR DESCRIPTION
Related to issue https://github.com/kodi-pvr/pvr.vdr.vnsi/issues/162

Here how now showed during Kodi's start of if the backend connection was not available on Kodi start and done later.

![Bildschirmfoto vom 2022-01-15 21-56-22](https://user-images.githubusercontent.com/6879739/149637448-2406a76d-2290-4d26-b9f3-fbe2506652f5.png)

The way how fixed not the best, but it works.
With the `kodi::addon::CInstancePVRClient::ConnectionStateChange` call to Kodi, the process was blocked for some seconds and all other tries has created read errors in this time.
By this was then e.g. the timer data wrong or the asked interface version has given 0 (relates to other errors reported by @phunkyfish).
This change makes them now on Kodi's start by "Start" call and on restarts by independent thread.