### PR TITLE
Use channel name for logos if picon doesn't exists

### DIFF
--- a/pvr.vdr.vnsi/addon.xml.in
+++ b/pvr.vdr.vnsi/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="20.2.3"
+  version="20.3.0"
   name="VDR VNSI Client"
   provider-name="Team Kodi, FernetMenta">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vdr.vnsi/changelog.txt
+++ b/pvr.vdr.vnsi/changelog.txt
@@ -1,3 +1,6 @@
+v20.3.0
+- If picon named logo doesn't exists channel name is used in logo filename
+
 v20.2.3
 - Fix Kodi crash upon reconnect
 

--- a/src/ClientInstance.cpp
+++ b/src/ClientInstance.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <kodi/General.h>
 #include <kodi/Network.h>
+#include <kodi/Filesystem.h>
 #include <string.h>
 #include <time.h>
 
@@ -387,14 +388,22 @@ PVR_ERROR CVNSIClientInstance::GetChannels(bool radio, kodi::addon::PVRChannelsR
       if (m_protocol >= 6)
       {
         std::string path = CVNSISettings::Get().GetIconPath();
-        std::string ref = vresp->extract_String();
+        std::string ref = vresp->extract_String(); // Picon ref
         if (!path.empty())
         {
           if (path[path.length() - 1] != '/')
             path += '/';
-          path += ref;
-          path += ".png";
-          tag.SetIconPath(path);
+
+          ref += ".png";
+          std::string image_path = path + ref;
+          if (!kodi::vfs::FileExists(image_path)) // Use channel name
+          {
+            std::string channelNameImage = tag.GetChannelName();
+            std::transform(channelNameImage.begin(), channelNameImage.end(), channelNameImage.begin(), ::tolower);
+            channelNameImage += ".png";
+            image_path = path + channelNameImage;
+          }
+          tag.SetIconPath(image_path);
         }
       }
       tag.SetIsRadio(radio);


### PR DESCRIPTION
Currently channel logos are only set to use picon naming example 1_0_19_5DD_E_0_FFFF0000_0_0_0.png
This PR makes VNSI Client check that file exists and if not then we use channel name for file.

I think it is more common that channel logos are named after channel name than picon ref.