### PR TITLE
Support for backend artwork, extra info and resumepoints

### DIFF
--- a/pvr.vdr.vnsi/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vdr.vnsi/resources/language/resource.language.en_gb/strings.po
@@ -232,7 +232,15 @@ msgctxt "#30050"
 msgid "Read chunksize for recordings"
 msgstr ""
 
-#empty strings from id 30051 to 30099
+msgctxt "#30051"
+msgid "Store recording resume location in VDR"
+msgstr ""
+
+msgctxt "#30052"
+msgid "When disabled resume location and watched status will be managed only in Kodi"
+msgstr ""
+
+#empty strings from id 30053 to 30099
 
 msgctxt "#30100"
 msgid "VDR OSD"

--- a/pvr.vdr.vnsi/resources/settings.xml
+++ b/pvr.vdr.vnsi/resources/settings.xml
@@ -79,6 +79,10 @@
           <default>65536</default>
           <control type="edit" format="integer" />
         </setting>
+        <setting help="30052" id="backendresume" type="boolean" label="30051">
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
   </section>

--- a/src/ClientInstance.h
+++ b/src/ClientInstance.h
@@ -92,6 +92,11 @@ public:
   PVR_ERROR RenameRecording(const kodi::addon::PVRRecording& recording) override;
   PVR_ERROR GetRecordingEdl(const kodi::addon::PVRRecording& recording,
                             std::vector<kodi::addon::PVREDLEntry>& edl) override;
+  PVR_ERROR GetRecordingLastPlayedPosition(const kodi::addon::PVRRecording& recording,
+                                           int& position) override;
+  PVR_ERROR SetRecordingLastPlayedPosition(const kodi::addon::PVRRecording& recording,
+                                           int lastplayedposition) override;
+  PVR_ERROR SetRecordingPlayCount(const kodi::addon::PVRRecording& recording, int count) override;
 
   //--==----==----==----==----==----==----==----==----==----==----==----==----==
 
@@ -175,4 +180,8 @@ private:
   std::atomic<bool> m_running = {false};
   std::thread m_thread;
   std::thread m_startInformThread;
+
+  // update these at end of counting loop can be called during action
+  std::map<int, int> m_lastPlayed;
+  std::map<int, int> m_playCount;
 };

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -118,6 +118,15 @@ bool CVNSISettings::Load()
     m_iChunkSize = DEFAULT_CHUNKSIZE;
   }
 
+  // Read setting "backendresume" from settings.xml
+  if (!kodi::addon::CheckSettingBoolean("backendresume", m_bBackendResume))
+  {
+    // If setting is unknown fallback to defaults
+    kodi::Log(ADDON_LOG_ERROR,
+              "Couldn't get 'backendresume' setting, falling back to 'false' as default");
+    m_bBackendResume = DEFAULT_BACKENDRESUME;
+  }
+
   return true;
 }
 
@@ -194,6 +203,16 @@ ADDON_STATUS CVNSISettings::SetSetting(const std::string& settingName,
     kodi::Log(ADDON_LOG_INFO, "Changed Setting 'chunksize' from %u to %u", m_iChunkSize,
               settingValue.GetInt());
     m_iChunkSize = settingValue.GetInt();
+  }
+  else if (settingName == "backendresume")
+  {
+    kodi::Log(ADDON_LOG_INFO, "Changed Setting 'backendresume' from %u to %u",
+              m_bBackendResume, settingValue.GetBoolean());
+    if (m_bBackendResume != settingValue.GetBoolean())
+    {
+      m_bBackendResume = settingValue.GetBoolean();
+      return ADDON_STATUS_NEED_RESTART;
+    }
   }
 
   return ADDON_STATUS_OK;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -18,6 +18,7 @@
 #define DEFAULT_TIMEOUT 3
 #define DEFAULT_AUTOGROUPS false
 #define DEFAULT_CHUNKSIZE 65536
+#define DEFAULT_BACKENDRESUME false
 
 class ATTR_DLL_LOCAL CVNSISettings
 {
@@ -38,6 +39,7 @@ public:
   int GetTimeshift() const { return m_iTimeshift; }
   const std::string& GetIconPath() const { return m_szIconPath; }
   int GetChunkSize() const { return m_iChunkSize; }
+  bool GetBackendResume() const { return m_bBackendResume; }
 
 private:
   CVNSISettings() = default;
@@ -56,4 +58,5 @@ private:
   int m_iTimeshift = 1;
   std::string m_szIconPath; /*!< path to channel icons */
   int m_iChunkSize = DEFAULT_CHUNKSIZE;
+  bool m_bBackendResume = DEFAULT_BACKENDRESUME;
 };

--- a/src/vnsicommand.h
+++ b/src/vnsicommand.h
@@ -9,7 +9,7 @@
 #pragma once
 
 /** Current VNSI Protocol Version number */
-#define VNSI_PROTOCOLVERSION 13
+#define VNSI_PROTOCOLVERSION 14
 
 /** Start of RDS support protocol Version */
 #define VNSI_RDS_PROTOCOLVERSION 8
@@ -90,6 +90,7 @@
 #define VNSI_RECORDINGS_RENAME 103
 #define VNSI_RECORDINGS_DELETE 104
 #define VNSI_RECORDINGS_GETEDL 105
+#define VNSI_RECORDINGS_SETLASTPLAYEDPOSITION 106
 
 /* OPCODE 120 - 139: VNSI network functions for epg access and manipulating */
 #define VNSI_EPG_GETFORCHANNEL 120


### PR DESCRIPTION
This PR adds support for backend provided extra info (artwork, actors, directors etc.) and updating watching progress between backend and Kodi.

Also protocol version is bump to 14 for compatibility to older vnsiserver.

This can be merged before changes are in vnsiserver without breaking things for users but there's probably no point to do that. I still need to investigate how changes to vnsiserver can be reviewed and merged.

Currently compatible vnsiserver is in here https://github.com/Dis90/vdr-plugin-vnsiserver/tree/tvscraper_backendresume