### PR TITLE
[Matrix] Fix for crash in method OnReconnect()

### DIFF
--- a/pvr.vdr.vnsi/addon.xml.in
+++ b/pvr.vdr.vnsi/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="19.0.3"
+  version="19.0.4"
   name="VDR VNSI Client"
   provider-name="Team Kodi, FernetMenta">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vdr.vnsi/changelog.txt
+++ b/pvr.vdr.vnsi/changelog.txt
@@ -1,3 +1,6 @@
+v19.0.4
+- Fix Kodi crash upon reconnect
+
 v19.0.3
 - Fix connection errors on Kodi start and during backend reconnections
 

--- a/src/ClientInstance.cpp
+++ b/src/ClientInstance.cpp
@@ -118,6 +118,9 @@ void CVNSIClientInstance::OnReconnect()
 {
   EnableStatusInterface(true, false);
 
+  if (m_startInformThread.joinable())
+    m_startInformThread.join();
+
   m_startInformThread = std::thread([&]() {
     kodi::addon::CInstancePVRClient::ConnectionStateChange("vnsi connection established",
                                                           PVR_CONNECTION_STATE_CONNECTED,


### PR DESCRIPTION
When Kodi is running and the PC wakes up from suspend, Kodi will crash. After going through the debug log, the crash happens in CVNSIClientInstance::OnReconnect().
As of #174 the the logic for a reconnect is moved into a thread, for a reason I don't understand. When the thread has not finished and OnReconnect() is called again (for what ever reason), it raises an exception  per definition (thread is joinable).