### PR TITLE
Fix SwitchChannel() heap-use-after-free

### DIFF
--- a/src/InputstreamDemux.cpp
+++ b/src/InputstreamDemux.cpp
@@ -312,7 +312,9 @@ bool cVNSIDemux::SwitchChannel(const kodi::addon::PVRChannel& channelinfo)
     }
   }
 
-  m_channelinfo = channelinfo;
+  if (&m_channelinfo != &channelinfo)
+    m_channelinfo = channelinfo;
+
   m_MuxPacketSerial = 0;
   m_ReferenceTime = 0;
   m_minPTS = 0;


### PR DESCRIPTION
==25873==ERROR: AddressSanitizer: heap-use-after-free on address 0xb4b79e80 at pc 0xc1027fe7 bp 0xb0bcb968 sp 0xb0bcb96c
READ of size 2108 at 0xb4b79e80 thread T26
    #0 0xc1027fe4 in kodi::addon::CStructHdl<kodi::addon::PVRChannel, PVR_CHANNEL>::operator=(kodi::addon::CStructHdl<kodi::addon::PVRChannel, PVR_CHANNEL> const&) pvr-vdr-vnsi-Matrix-c4c9a5c4edd212462af4465246183ef2fc9993a9/src/InputstreamDemux.cpp:285
    #1 0xc1027fe4 in kodi::addon::PVRChannel::operator=(kodi::addon::PVRChannel const&) /usr/local/include/kodi/addon-instance/pvr/Channels.h:38
    #2 0xc1027fe4 in cVNSIDemux::SwitchChannel(kodi::addon::PVRChannel const&) pvr-vdr-vnsi-Matrix-c4c9a5c4edd212462af4465246183ef2fc9993a9/src/InputstreamDemux.cpp:315
    #3 0xc0eb6158 in CVNSIClientInstance::OpenLiveStream(kodi::addon::PVRChannel const&) pvr-vdr-vnsi-Matrix-c4c9a5c4edd212462af4465246183ef2fc9993a9/src/ClientInstance.cpp:1517
    #4 0xc0f1aad2 in kodi::addon::CInstancePVRClient::ADDON_OpenLiveStream(AddonInstance_PVR const*, PVR_CHANNEL const*) (/usr/local/lib/kodi/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.so.19.0.5+0x1daad2)
    #5 0x1753f0e in operator() xbmc-Matrix-11fcf3089436c701b86b98658d646730cf35136d/xbmc/pvr/addons/PVRClient.cpp:1425