### PR TITLE
[Nexus] Increase version to 20.4.0

### DIFF
--- a/pvr.vdr.vnsi/addon.xml.in
+++ b/pvr.vdr.vnsi/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="20.3.1"
+  version="20.4.0"
   name="VDR VNSI Client"
   provider-name="Team Kodi, FernetMenta">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vdr.vnsi/changelog.txt
+++ b/pvr.vdr.vnsi/changelog.txt
@@ -1,3 +1,6 @@
+v20.4.0
+- Kodi inputstream API update to version 3.2.0
+
 v20.3.1
 - Fix further crashes on some channels
 


### PR DESCRIPTION
Bump version for inpustream API change
due to:
https://github.com/xbmc/xbmc/pull/21390
https://github.com/xbmc/xbmc/pull/21319
