### PR TITLE
[Nexus] Fix Admin window on GLES / Warn if skin is not supported

### DIFF
--- a/pvr.vdr.vnsi/addon.xml.in
+++ b/pvr.vdr.vnsi/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="20.4.0"
+  version="20.4.1"
   name="VDR VNSI Client"
   provider-name="Team Kodi, FernetMenta">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.vdr.vnsi/changelog.txt
+++ b/pvr.vdr.vnsi/changelog.txt
@@ -1,3 +1,6 @@
+v20.4.1
+- Fix display of "Client Specific Settings" on GLES
+
 v20.4.0
 - Kodi inputstream API update to version 3.2.0
 - Kodi PVR API update to version 8.0.2

--- a/pvr.vdr.vnsi/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vdr.vnsi/resources/language/resource.language.en_gb/strings.po
@@ -319,3 +319,13 @@ msgstr ""
 msgctxt "#30205"
 msgid "Repeating Child"
 msgstr ""
+
+msgctxt "#30205"
+msgid "Repeating Child"
+msgstr ""
+
+#empty strings from id 30206 to 30299
+
+msgctxt "#30300"
+msgid "The Skin is not supported"
+msgstr ""

--- a/pvr.vdr.vnsi/resources/shaders/GLES/vert.glsl
+++ b/pvr.vdr.vnsi/resources/shaders/GLES/vert.glsl
@@ -5,6 +5,9 @@ attribute vec2 a_coord;
 
 varying vec2 v_coord;
 
+uniform mat4 m_proj;
+uniform mat4 m_model;
+
 void main()
 {
   mat4 mvp = m_proj * m_model;

--- a/src/GUIWindowAdmin.cpp
+++ b/src/GUIWindowAdmin.cpp
@@ -14,6 +14,7 @@
 
 #include <kodi/General.h>
 #include <kodi/Network.h>
+#include <kodi/gui/dialogs/OK.h>
 #include <kodi/gui/gl/GL.h>
 #include <kodi/gui/gl/Shader.h>
 #include <queue>
@@ -562,6 +563,13 @@ bool cVNSIAdmin::Open(const std::string& hostname,
   m_hostname = hostname;
   m_port = port;
   m_wolMac = mac;
+
+  if (nullptr == GetControlHandle())
+  {
+    kodi::gui::dialogs::OK::ShowAndGetInput(
+        "pvr.vdr.vnsi", kodi::addon::GetLocalizedString(30300, "The Skin is not supported"));
+    return false;
+  }
 
   if (!cVNSISession::Open(m_hostname, m_port, name))
     return false;

--- a/src/GUIWindowAdmin.cpp
+++ b/src/GUIWindowAdmin.cpp
@@ -570,7 +570,7 @@ bool cVNSIAdmin::Open(const std::string& hostname,
     return false;
 
   m_bIsOsdControl = false;
-#if defined(HAS_GL) || defined(HAS_GLES2)
+#if defined(HAS_GL) || defined(HAS_GLES)
   m_osdRender = new cOSDRenderGL();
 #else
   m_osdRender = new cOSDRender();


### PR DESCRIPTION
Fix for #141 "Client Specific Settings" were only shown with GL.

HAVE_GLES2 was never defined in FindOpenGLES.cmake. In addition vert.glsl needed to be fixed:
```
2023-02-27 15:52:04.925 T:1734     info <general>: Loading skin file: /storage/.kodi/addons/pvr.vdr.vnsi/resources/skins/skin.estuary/xml/Admin.xml, load type: LOAD_ON_GUI_INIT
2023-02-27 15:52:04.931 T:1734    debug <general>: [Warning] CGUITextureManager::GetTexturePath: could not find texture '-'
2023-02-27 15:52:04.932 T:1734    error <general>: AddOnLog: pvr.vdr.vnsi: CVertexShader::Compile: 0:10(13): error: `m_proj' undeclared
                                                   0:10(22): error: `m_model' undeclared
                                                   0:10(13): error: operands to arithmetic operators must be numeric
                                                   
2023-02-27 15:52:04.932 T:1734    error <general>: AddOnLog: pvr.vdr.vnsi: GL: Error compiling vertex shader
```
With this PR the Admin window is visible in LibreELEC Generic (GBM).

---

Second commit is to add a warning dialog if the skin is not supported.

---

Increase version to 20.4.1 and update changelog.

Backport of #203