### PR TITLE
[Nexus] en_gb strings.po: fix duplicate entry 30205

### DIFF
--- a/pvr.vdr.vnsi/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.vdr.vnsi/resources/language/resource.language.en_gb/strings.po
@@ -320,10 +320,6 @@ msgctxt "#30205"
 msgid "Repeating Child"
 msgstr ""
 
-msgctxt "#30205"
-msgid "Repeating Child"
-msgstr ""
-
 #empty strings from id 30206 to 30299
 
 msgctxt "#30300"


### PR DESCRIPTION
Bug was introduced in #204 

Backport of #207