### PR TITLE
FindOpenGL: fix compile failure on GLVND linux systems

### DIFF
--- a/FindOpenGl.cmake
+++ b/FindOpenGl.cmake
@@ -17,7 +17,7 @@ endif()
 if(NOT CORE_SYSTEM_NAME STREQUAL osx)
   find_path(OPENGL_INCLUDE_DIR GL/gl.h
                                PATHS ${PC_OPENGL_gl_INCLUDEDIR})
-  find_library(OPENGL_gl_LIBRARY NAMES GL
+  find_library(OPENGL_gl_LIBRARY NAMES GL OpenGL
                                  PATHS ${PC_OPENGL_gl_LIBDIR})
 else()
   find_library(OPENGL_gl_LIBRARY NAMES OpenGL


### PR DESCRIPTION
Fixes #248. Tested in GLVND and X11 build environments.